### PR TITLE
API Tests Fixes

### DIFF
--- a/src/main/java/com/solvd/carina/demo/api/albums/GetAlbumMethod.java
+++ b/src/main/java/com/solvd/carina/demo/api/albums/GetAlbumMethod.java
@@ -6,13 +6,11 @@ import com.zebrunner.carina.api.annotation.ResponseTemplatePath;
 import com.zebrunner.carina.api.annotation.SuccessfulHttpStatus;
 import com.zebrunner.carina.api.http.HttpMethodType;
 import com.zebrunner.carina.api.http.HttpResponseStatusType;
-import com.zebrunner.carina.utils.config.Configuration;
 
 @Endpoint(url = "${config.env.base_url}/albums", methodType = HttpMethodType.GET)
 @ResponseTemplatePath(path = "api/albums/_get/rs.json")
 @SuccessfulHttpStatus(status = HttpResponseStatusType.OK_200)
 public class GetAlbumMethod extends AbstractApiMethodV2 {
     public GetAlbumMethod() {
-        replaceUrlPlaceholder("base_url", Configuration.getRequired("api_url"));
     }
 }

--- a/src/main/java/com/solvd/carina/demo/api/albums/GetAlbumMethod.java
+++ b/src/main/java/com/solvd/carina/demo/api/albums/GetAlbumMethod.java
@@ -8,7 +8,7 @@ import com.zebrunner.carina.api.http.HttpMethodType;
 import com.zebrunner.carina.api.http.HttpResponseStatusType;
 import com.zebrunner.carina.utils.config.Configuration;
 
-@Endpoint(url = "${base_url}/albums", methodType = HttpMethodType.GET)
+@Endpoint(url = "${config.env.base_url}/albums", methodType = HttpMethodType.GET)
 @ResponseTemplatePath(path = "api/albums/_get/rs.json")
 @SuccessfulHttpStatus(status = HttpResponseStatusType.OK_200)
 public class GetAlbumMethod extends AbstractApiMethodV2 {

--- a/src/main/java/com/solvd/carina/demo/api/albums/GetAlbumMethod.java
+++ b/src/main/java/com/solvd/carina/demo/api/albums/GetAlbumMethod.java
@@ -7,7 +7,7 @@ import com.zebrunner.carina.api.annotation.SuccessfulHttpStatus;
 import com.zebrunner.carina.api.http.HttpMethodType;
 import com.zebrunner.carina.api.http.HttpResponseStatusType;
 
-@Endpoint(url = "${config.env.base_url}/albums", methodType = HttpMethodType.GET)
+@Endpoint(url = "${config.env.api_url}/albums", methodType = HttpMethodType.GET)
 @ResponseTemplatePath(path = "api/albums/_get/rs.json")
 @SuccessfulHttpStatus(status = HttpResponseStatusType.OK_200)
 public class GetAlbumMethod extends AbstractApiMethodV2 {

--- a/src/main/java/com/solvd/carina/demo/api/albums/PatchAlbumMethod.java
+++ b/src/main/java/com/solvd/carina/demo/api/albums/PatchAlbumMethod.java
@@ -8,7 +8,7 @@ import com.zebrunner.carina.api.annotation.SuccessfulHttpStatus;
 import com.zebrunner.carina.api.http.HttpMethodType;
 import com.zebrunner.carina.api.http.HttpResponseStatusType;
 
-@Endpoint(url = "${config.env.api_url}/albums/101", methodType = HttpMethodType.PATCH)
+@Endpoint(url = "${config.env.api_url}/albums/${id}", methodType = HttpMethodType.PATCH)
 @RequestTemplatePath(path = "api/albums/_patch/rq.json")
 @ResponseTemplatePath(path = "api/albums/_patch/rs.json")
 @SuccessfulHttpStatus(status = HttpResponseStatusType.OK_200)

--- a/src/main/java/com/solvd/carina/demo/api/albums/PatchAlbumMethod.java
+++ b/src/main/java/com/solvd/carina/demo/api/albums/PatchAlbumMethod.java
@@ -7,16 +7,14 @@ import com.zebrunner.carina.api.annotation.ResponseTemplatePath;
 import com.zebrunner.carina.api.annotation.SuccessfulHttpStatus;
 import com.zebrunner.carina.api.http.HttpMethodType;
 import com.zebrunner.carina.api.http.HttpResponseStatusType;
-import com.zebrunner.carina.utils.config.Configuration;
 
-@Endpoint(url = "${base_url}/albums/101", methodType = HttpMethodType.PATCH)
+@Endpoint(url = "${config.env.api_url}/albums/101", methodType = HttpMethodType.PATCH)
 @RequestTemplatePath(path = "api/albums/_patch/rq.json")
 @ResponseTemplatePath(path = "api/albums/_patch/rs.json")
 @SuccessfulHttpStatus(status = HttpResponseStatusType.OK_200)
 public class PatchAlbumMethod extends AbstractApiMethodV2 {
 
     public PatchAlbumMethod() {
-        replaceUrlPlaceholder("base_url", Configuration.getRequired("api_url"));
     }
 }
 

--- a/src/main/java/com/solvd/carina/demo/api/albums/PostAlbumMethod.java
+++ b/src/main/java/com/solvd/carina/demo/api/albums/PostAlbumMethod.java
@@ -7,15 +7,13 @@ import com.zebrunner.carina.api.annotation.ResponseTemplatePath;
 import com.zebrunner.carina.api.annotation.SuccessfulHttpStatus;
 import com.zebrunner.carina.api.http.HttpMethodType;
 import com.zebrunner.carina.api.http.HttpResponseStatusType;
-import com.zebrunner.carina.utils.config.Configuration;
 
-@Endpoint(url = "${base_url}/albums", methodType = HttpMethodType.POST)
+@Endpoint(url = "${config.env.api_url}/albums", methodType = HttpMethodType.POST)
 @RequestTemplatePath(path = "api/albums/_post/rq.json")
 @ResponseTemplatePath(path = "api/albums/_post/rs.json")
 @SuccessfulHttpStatus(status = HttpResponseStatusType.CREATED_201)
 public class PostAlbumMethod extends AbstractApiMethodV2 {
 
     public PostAlbumMethod() {
-        replaceUrlPlaceholder("base_url", Configuration.getRequired("api_url"));
     }
 }

--- a/src/main/resources/_config.properties
+++ b/src/main/resources/_config.properties
@@ -1,24 +1,19 @@
 #=====================================================#
 #================= Configuration v2 ==================#
 #=====================================================#
-
 #=================== Global configuration ============#
 url=https://www.gsmarena.com
-capabilities.browserName=NULL
+capabilities.browserName=chrome
 capabilities.browserVersion=NULL
-#selenium_url=http://localhost:4444/wd/hub
+selenium_url=http://localhost:4444/wd/hub
 custom_capabilities=NULL
 extra_capabilities=NULL
 app_version=
-
 #desired thread count for parallel execution. If commented "thread-count" value from TestNG suite xml is used.
 #thread_count=1
-
 #desired thread count for data provider(s). If commented "data-provider-thread-count" value from TestNG suite xml is used.
 #data_provider_thread_count=1
-
 #=====================================================#
-
 #=============== Environment configuration ===========#
 env=DEMO
 DEMO.base=https://www.gsmarena.com
@@ -26,26 +21,22 @@ DEMO.api_url=https://jsonplaceholder.typicode.com
 STAG.api_url=
 DEMO.soap_url=https://www.crcind.com:443/csp/samples/SOAP.Demo.cls
 #=====================================================#
-
 #============== Locale Configurations ================#
 locale=en_US
 localization_testing=false
 localization_encoding=UTF-8
 language=en_US
 #=====================================================#
-
 #================ Retry configuration ================#
 #number of extra retries to execute tests until pass
 retry_count=0
 #=====================================================#
-
 #============== WebDriver configuration ==============#
 explicit_timeout=20
 #number of extra retries to start driver session and interval in seconds
 init_retry_count=0
 init_retry_interval=1
 #=====================================================#
-
 #uncomment and change udid and deviceName for Android test
 #============ Android Local Mobile ===================#
 #selenium_url=http://localhost:4723/wd/hub
@@ -56,7 +47,6 @@ init_retry_interval=1
 #capabilities.platformName=ANDROID
 #capabilities.app=https://qaprosoft.s3-us-west-2.amazonaws.com/carinademoexample.apk
 #=====================================================#
-
 #uncomment and change deviceName and platformVersion for iOS test
 #======== Local Run for iOS Mobile ===============#
 #selenium_url=http://localhost:4723/wd/hub
@@ -68,47 +58,39 @@ init_retry_interval=1
 #capabilities.udid=
 #capabilities.app=https://qaprosoft.s3-us-west-2.amazonaws.com/carinademoexample.zip
 #=====================================================#
-
 #================ Report configuration ===============#
 core_log_level=INFO
 auto_screenshot=true
 project_report_directory=./reports
 report_url=NULL
 max_screen_history=10
-
 email_list=NULL
 suite_name=NULL
 #=====================================================#
-
 #=============== MyBatis configuration ===============#
 mybatis_cnfg=mybatis.config.xml
 mybatis_env=testing
 #=====================================================#
-
 #====================== TestRail =====================#
 testrail_milestone=NULL
 testrail_assignee=NULL
 #=====================================================#
-
 #===================== Amazon ========================#
 s3_bucket_name=NULL
 access_key_id=NULL
 secret_key=NULL
 #=====================================================#
-
 #===================== Azure =========================#
 azure_account_name=NULL
 azure_blob_url=https://${azure_account_name}.blob.core.windows.net
 azure_access_key_token=NULL
 azure_local_storage=NULL
 #=====================================================#
-
 #===================== Crypto ========================#
 crypto_key_value=OIujpEmIVZ0C9kOkXniFRw==
 #=====================================================#
 password={crypt:8O9iA4+f3nMzz85szmvKmQ==}
 credentials=test@gmail.com/${password}
-
 #==================== Proxy =====================#
 # for custom dynamic proxy
 proxy_chain_host=NULL

--- a/src/test/java/com/solvd/carina/demo/AlbumsApiTest.java
+++ b/src/test/java/com/solvd/carina/demo/AlbumsApiTest.java
@@ -26,7 +26,7 @@ public class AlbumsApiTest implements IAbstractTest {
 
     @Test()
     @MethodOwner(owner = "dshaur")
-    public void testCreateAlbum() throws Exception {
+    public void testCreateAlbum() {
         PostAlbumMethod api = new PostAlbumMethod();
         api.setProperties("api/albums/album.properties");
         api.callAPIExpectSuccess();
@@ -35,7 +35,7 @@ public class AlbumsApiTest implements IAbstractTest {
 
     @Test()
     @MethodOwner(owner = "dshaur")
-    public void testCreateAlbumMissingSomeFields() throws Exception {
+    public void testCreateAlbumMissingSomeFields() {
         PostAlbumMethod api = new PostAlbumMethod();
         api.setProperties("api/albums/album.properties");
         api.getProperties().remove("title");
@@ -56,21 +56,24 @@ public class AlbumsApiTest implements IAbstractTest {
     // Test PATCH, first use POST call to create album and then use PATCH
     @Test()
     @MethodOwner(owner = "dshaur")
-    public void testPatchAlbum() throws Exception {
+    public void testPatchAlbum() {
         // Step 1: Create an album using POST call
         PostAlbumMethod postApi = new PostAlbumMethod();
         postApi.setProperties("api/albums/album.properties");
         Response postResponse = postApi.callAPIExpectSuccess();
-        postApi.validateResponse();
 
         // Step 2: Get the ID of the created album
-        String albumId = postResponse.jsonPath().getString("0.id");
-        LOGGER.info(albumId);
+        String postId = postResponse.jsonPath().getString("id");
+        LOGGER.info(postId);
+
+        String postUrl = String.valueOf(postResponse.getHeaders().getValue("location"));
+        LOGGER.info(postUrl);
 
         // Step 3: Update the created album using PATCH call
         PatchAlbumMethod patchAlbumMethod = new PatchAlbumMethod();
+        patchAlbumMethod.replaceUrlPlaceholder("${config.env.api_url}/albums", postUrl);
         patchAlbumMethod.setProperties("api/albums/album.properties");
         patchAlbumMethod.callAPIExpectSuccess();
-        //patchAlbumMethod.validateResponse();
+        patchAlbumMethod.validateResponse();
     }
 }

--- a/src/test/java/com/solvd/carina/demo/AlbumsApiTest.java
+++ b/src/test/java/com/solvd/carina/demo/AlbumsApiTest.java
@@ -66,12 +66,10 @@ public class AlbumsApiTest implements IAbstractTest {
         String postId = postResponse.jsonPath().getString("id");
         LOGGER.info(postId);
 
-        String postUrl = String.valueOf(postResponse.getHeaders().getValue("location"));
-        LOGGER.info(postUrl);
 
         // Step 3: Update the created album using PATCH call
         PatchAlbumMethod patchAlbumMethod = new PatchAlbumMethod();
-        patchAlbumMethod.replaceUrlPlaceholder("${config.env.api_url}/albums", postUrl);
+        patchAlbumMethod.replaceUrlPlaceholder("id", postId);
         patchAlbumMethod.setProperties("api/albums/album.properties");
         patchAlbumMethod.callAPIExpectSuccess();
         patchAlbumMethod.validateResponse();

--- a/src/test/resources/api/albums/_patch/rs.json
+++ b/src/test/resources/api/albums/_patch/rs.json
@@ -1,5 +1,3 @@
 {
-  "userId": "regex:[\\d]",
-  "id": "regex:[\\d]",
   "title": "regex:[a-zA-Z\\d]+"
 }

--- a/src/test/resources/api/albums/_post/rq.json
+++ b/src/test/resources/api/albums/_post/rq.json
@@ -1,7 +1,8 @@
 [
   {
-    <#if title??>"title": "${title}",</#if>
     "userId": 1,
     "id": 1
+    <#if title??>,
+    "title": "${title}"</#if>
   }
 ]


### PR DESCRIPTION
* Fixed POST request json file to use Freemarker to remove extra commas ',' when properties get removed.
* Removed unused exceptions. 
* Fixed Album HTTP Method classes to use ${config.env.api_url} instead of replacing url placeholders in their constructors. 
* Fixed PATCH rs.json to only expect the updated properties. 
* Fixed testPatchAlbum() method to use the ID from POST and call it in the PATCH url.